### PR TITLE
Update 20240229_wg21_paper_202312.md

### DIFF
--- a/2024/20240229_wg21_paper_202312.md
+++ b/2024/20240229_wg21_paper_202312.md
@@ -718,7 +718,7 @@ C++26に向けての、`<ranges>`ライブラリ関連作業の予定表。
 
 以前の記事を参照
 
-- [P2758R0 Emitting messages at compile time - WG21月次提案文書を眺める（2023年01月）](https://onihusube.hatenablog.com/entry/2023/02/12/210302#P2758R0-Emitting-messages-at-compile-time)
+- [P2760R0 A Plan for C++26 Ranges - WG21月次提案文書を眺める（2023年12月）](https://onihusube.hatenablog.com/entry/2023/10/29/180915#P2760R0-A-Plan-for-C26-Ranges)
 
 このリビジョンでの変更は、`output_iterator`の改善と並行アルゴリズムサポートについてを優先度1に追加した事です。
 


### PR DESCRIPTION
記事内のリンク修正: P2758R0のリンク先をP2760R0に更新